### PR TITLE
Limit access to bridgehead configuration repository

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -84,10 +84,10 @@ Example:
 
 ### GitLab Project Access Token
 
-Create a GitLab project access token for read access (git clone/pull) to a repository.
+Create a GitLab project access token for read access (git clone/pull) to the bridgehead configuration repository.
 
 Secret type: `GitLabProjectAccessToken`
 
-The argument is the path to the repository on GitLab, typically of the format "group/project".
+The argument is always `bridgehead-configuration`.
 
-Example: `GitLabProjectAccessToken:foobar:bridgehead-configurations/foobar`
+Example: `GitLabProjectAccessToken:GIT_CONFIG_REPO_TOKEN:bridgehead-configuration`

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -2,7 +2,7 @@ use beam_lib::{reqwest::Url, AppId};
 use clap::Parser;
 use serde::Deserialize;
 use serde_json::json;
-use shared::{GitLabProject, SecretResult};
+use shared::SecretResult;
 
 #[derive(Parser)]
 struct GitLabApiConfig {
@@ -64,11 +64,8 @@ impl GitLabProjectAccessTokenProvider {
     pub async fn create_token(
         &self,
         requester: &AppId,
-        client_config: GitLabProject,
     ) -> Result<SecretResult, String> {
-        let project_path = match client_config {
-            GitLabProject::BridgeheadConfiguration => derive_bridgehead_config_repo_from_beam_id(requester)?
-        };
+        let project_path = derive_bridgehead_config_repo_from_beam_id(requester)?;
 
         // Expire in 1 week
         let expires_at = (chrono::Local::now() + chrono::TimeDelta::weeks(1))
@@ -117,11 +114,8 @@ impl GitLabProjectAccessTokenProvider {
         &self,
         requester: &AppId,
         secret: &str,
-        client_config: &GitLabProject,
     ) -> Result<bool, String> {
-        let project_path = match client_config {
-            GitLabProject::BridgeheadConfiguration => derive_bridgehead_config_repo_from_beam_id(requester)?
-        };
+        let project_path = derive_bridgehead_config_repo_from_beam_id(requester)?;
 
         let response = self
             .client

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -36,7 +36,7 @@ fn derive_bridgehead_config_repo_from_beam_id(requester: &AppId) -> Result<Strin
         "broker.bbmri.de" => "bbmri-bridgehead-configs", // gbn
         "test-no-real-data.broker.samply.de" => "bridgehead-configurations", // cce, itcc, kr
         "broker.hector.dkfz.de" => "dhki", // dhki
-        _ => return Err(format!("Bridgehead configuration repository not known for beam id {requester}")),
+        _ => return Err(format!("Bridgehead configuration repository group not known for broker {broker}")),
     };
 
     Ok(match group {

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -1,8 +1,8 @@
-use beam_lib::reqwest::Url;
+use beam_lib::{reqwest::Url, AppId};
 use clap::Parser;
 use serde::Deserialize;
 use serde_json::json;
-use shared::{GitLabProjectAccessTokenConfig, SecretResult};
+use shared::{GitLabProject, SecretResult};
 
 #[derive(Parser)]
 struct GitLabApiConfig {
@@ -24,6 +24,28 @@ pub struct GitLabProjectAccessTokenProvider {
     client: reqwest::Client,
 }
 
+/// Derive the bridgehead configuration repository from the beam id of the requester.
+/// Example return value: "bridgehead-configurations/bridgehead-config-berlin"
+fn derive_bridgehead_config_repo_from_beam_id(requester: &AppId) -> Result<String, String> {
+    let mut parts = requester.as_ref().splitn(3, '.');
+    let (_app, proxy, broker) = (parts.next().unwrap(), parts.next().unwrap(), parts.next().unwrap());
+
+    let group = match broker {
+        "broker.ccp-it.dktk.dkfz.de" => "bridgehead-configurations", // ccp
+        "broker.bbmri.sample.de" => "bbmri-bridgehead-configs", // bbmri
+        "broker.bbmri.de" => "bbmri-bridgehead-configs", // gbn
+        "test-no-real-data.broker.samply.de" => "bridgehead-configurations", // cce, itcc, kr
+        "broker.hector.dkfz.de" => "dhki", // dhki
+        _ => return Err(format!("Bridgehead configuration repository not known for beam id {requester}")),
+    };
+
+    Ok(match group {
+        "bridgehead-configurations" => format!("{group}/bridgehead-config-{proxy}"),
+        "dhki" => format!("{group}/{proxy}-bk"),
+        _ => format!("{group}/{proxy}"),
+    })
+}
+
 impl GitLabProjectAccessTokenProvider {
     pub fn try_init() -> Option<Self> {
         match GitLabApiConfig::try_parse() {
@@ -41,9 +63,13 @@ impl GitLabProjectAccessTokenProvider {
     /// Create a project access token using the GitLab API
     pub async fn create_token(
         &self,
-        name: &str,
-        client_config: GitLabProjectAccessTokenConfig,
+        requester: &AppId,
+        client_config: GitLabProject,
     ) -> Result<SecretResult, String> {
+        let project_path = match client_config {
+            GitLabProject::BridgeheadConfiguration => derive_bridgehead_config_repo_from_beam_id(requester)?
+        };
+
         // Expire in 1 week
         let expires_at = (chrono::Local::now() + chrono::TimeDelta::weeks(1))
             .format("%Y-%m-%d")
@@ -56,13 +82,13 @@ impl GitLabProjectAccessTokenProvider {
                     .gitlab_url
                     .join(&format!(
                         "api/v4/projects/{}/access_tokens",
-                        urlencoding::encode(&client_config.project_path)
+                        urlencoding::encode(&project_path)
                     ))
                     .map_err(|e| e.to_string())?,
             )
             .header("PRIVATE-TOKEN", &self.config.gitlab_api_access_token)
             .json(&json!({
-                "name": format!("secret-sync-{name}"),
+                "name": requester,
                 // The "read_repository" scope is required for git clone/pull permissions
                 "scopes": ["read_repository"],
                 // Access level 20 (Reporter) is the lowest level that allows git clone/pull
@@ -89,10 +115,14 @@ impl GitLabProjectAccessTokenProvider {
     /// Simulate a git fetch to check the validity of the token
     pub async fn validate_token(
         &self,
-        _name: &str,
+        requester: &AppId,
         secret: &str,
-        client_config: &GitLabProjectAccessTokenConfig,
+        client_config: &GitLabProject,
     ) -> Result<bool, String> {
+        let project_path = match client_config {
+            GitLabProject::BridgeheadConfiguration => derive_bridgehead_config_repo_from_beam_id(requester)?
+        };
+
         let response = self
             .client
             .get(
@@ -100,7 +130,7 @@ impl GitLabProjectAccessTokenProvider {
                     .gitlab_url
                     .join(&format!(
                         "{}.git/info/refs?service=git-upload-pack",
-                        client_config.project_path
+                        project_path
                     ))
                     .map_err(|e| e.to_string())?,
             )

--- a/central/src/main.rs
+++ b/central/src/main.rs
@@ -94,14 +94,14 @@ pub async fn create_secret(request: SecretRequest, requester: &AppId) -> Result<
             let name = requester.as_ref().split('.').nth(1).unwrap();
             oidc_provider.create_client(name, oidc_client_config).await
         }
-        SecretRequest::GitLabProjectAccessToken(token_config) => {
+        SecretRequest::GitLabProjectAccessToken => {
             let Some(gitlab_project_access_token_provider) =
                 GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER.as_ref()
             else {
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .create_token(requester, token_config)
+                .create_token(requester)
                 .await
         }
     }
@@ -118,14 +118,14 @@ pub async fn is_valid(secret: &str, request: &SecretRequest, requester: &AppId) 
                 .validate_client(name, secret, oidc_client_config)
                 .await
         }
-        SecretRequest::GitLabProjectAccessToken(token_config) => {
+        SecretRequest::GitLabProjectAccessToken => {
             let Some(gitlab_project_access_token_provider) =
                 GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER.as_ref()
             else {
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .validate_token(requester, secret, token_config)
+                .validate_token(requester, secret)
                 .await
         }
     }

--- a/dev-gitlab/docker-compose.yaml
+++ b/dev-gitlab/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - PROXY_ID=proxy1.broker
       - GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER=app2.proxy2.broker
       - BROKER_URL=http://broker:8080
-      - "SECRET_DEFINITIONS=GitLabProjectAccessToken:foobar:bridgehead-configurations-test/foobar\x1EGitLabProjectAccessToken:justatest:bridgehead-configurations-test/just-a-test-project"
+      - SECRET_DEFINITIONS=GitLabProjectAccessToken:GIT_CONFIG_REPO_TOKEN:bridgehead-configuration
       - CACHE_PATH=/usr/local/cache/cache.txt
     volumes:
       - ./cache:/usr/local/cache

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, convert::Infallible, str::FromStr};
 
 use beam_lib::AppId;
 use clap::Parser;
-use shared::{GitLabProjectAccessTokenConfig, OIDCConfig, SecretRequest};
+use shared::{GitLabProject, OIDCConfig, SecretRequest};
 
 /// Local secret sync
 #[derive(Debug, Parser)]
@@ -68,11 +68,12 @@ impl FromStr for SecretArg {
                     is_public,
                 }))
             }
-            "GitLabProjectAccessToken" => Ok(SecretRequest::GitLabProjectAccessToken(
-                GitLabProjectAccessTokenConfig {
-                    project_path: args.to_owned(),
-                },
-            )),
+            "GitLabProjectAccessToken" => {
+                match args {
+                    "bridgehead-configuration" => Ok(SecretRequest::GitLabProjectAccessToken(GitLabProject::BridgeheadConfiguration)),
+                    _ => return Err(format!("Invalid GitLabProjectAccessToken parameter '{args}'")),
+                }
+            }
             _ => Err(format!("Unknown secret type {secret_type}")),
         }?;
 

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, convert::Infallible, str::FromStr};
 
 use beam_lib::AppId;
 use clap::Parser;
-use shared::{GitLabProject, OIDCConfig, SecretRequest};
+use shared::{OIDCConfig, SecretRequest};
 
 /// Local secret sync
 #[derive(Debug, Parser)]
@@ -70,7 +70,7 @@ impl FromStr for SecretArg {
             }
             "GitLabProjectAccessToken" => {
                 match args {
-                    "bridgehead-configuration" => Ok(SecretRequest::GitLabProjectAccessToken(GitLabProject::BridgeheadConfiguration)),
+                    "bridgehead-configuration" => Ok(SecretRequest::GitLabProjectAccessToken),
                     _ => return Err(format!("Invalid GitLabProjectAccessToken parameter '{args}'")),
                 }
             }

--- a/local/src/main.rs
+++ b/local/src/main.rs
@@ -105,7 +105,7 @@ async fn send_secret_request(
     for secret_request in secret_requests {
         match secret_request.deref() {
             SecretRequest::OpenIdConnect(_) => oidc_requests.push(secret_request),
-            SecretRequest::GitLabProjectAccessToken(_) => {
+            SecretRequest::GitLabProjectAccessToken => {
                 gitlab_project_access_token_requests.push(secret_request)
             }
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,21 +6,13 @@ use serde::{Serialize, Deserialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum SecretRequest {
     OpenIdConnect(OIDCConfig),
-    GitLabProjectAccessToken(GitLabProject),
+    GitLabProjectAccessToken,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OIDCConfig {
     pub is_public: bool,
     pub redirect_urls: Vec<String>,
-}
-
-/// Describes the GitLab project for which a token is requested
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum GitLabProject {
-    /// Request a token for the bridgehead configuration repository of the respective site. The repository
-    /// is derived from the beam id of the secret sync local component that requests the token.
-    BridgeheadConfiguration,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Serialize, Deserialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum SecretRequest {
     OpenIdConnect(OIDCConfig),
-    GitLabProjectAccessToken(GitLabProjectAccessTokenConfig),
+    GitLabProjectAccessToken(GitLabProject),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -15,10 +15,12 @@ pub struct OIDCConfig {
     pub redirect_urls: Vec<String>,
 }
 
+/// Describes the GitLab project for which a token is requested
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GitLabProjectAccessTokenConfig {
-    /// Path to the repository on GitLab, typically of the format "group/project"
-    pub project_path: String,
+pub enum GitLabProject {
+    /// Request a token for the bridgehead configuration repository of the respective site. The repository
+    /// is derived from the beam id of the secret sync local component that requests the token.
+    BridgeheadConfiguration,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
This change enforces that secret sync clients can only request project access tokens for the bridgehead configuration repository of the respective site.