### PR TITLE
Add support for multiple GitLab servers to the GitLab backend

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,13 +69,13 @@ services:
       # The client secret for the client
       - AUTHENTIK_SECRET=my_secret
 
-      # Optional GitLab parameters
-      # The base URL for API calls, e.g. "https://gitlab.com/"
-      - GITLAB_URL=
+      # Optional GitLab parameters. More than one GitLab server can be configured by using different prefixes like "verbis" in this example.
+      # The base URL for API calls, e.g. "https://gitlab.com/".
+      - verbis_GITLAB_URL=
       # Format of the repository name on GitLab. Must contain a "#" which is replaced with the site name. Example: "bridgehead-configurations/bridgehead-config-#"
-      - GITLAB_REPO_FORMAT=
+      - verbis_GITLAB_REPO_FORMAT=
       # A long-living personal (or impersonation) access token that is used to create short-living project access tokens. Requires at least the "api" scope. Note that group access tokens and project access tokens cannot be used to create project access tokens.
-      - GITLAB_API_ACCESS_TOKEN=
+      - verbis_GITLAB_API_ACCESS_TOKEN=
 ```
 
 ## Secret types
@@ -99,6 +99,6 @@ Create a GitLab project access token for read access (git clone/pull) to the bri
 
 Secret type: `GitLabProjectAccessToken`
 
-The third value after the final `:` is unused.
+The third value after the final `:` is the prefix that identifies the GitLab server like e.g. "verbis". The central secret sync component must be configured with environment variables with this prefix.
 
 Example: `GitLabProjectAccessToken:GIT_CONFIG_REPO_TOKEN:`

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -37,16 +37,16 @@ fn parse_env_vars() -> HashMap<String, GitLabServerConfig> {
             let gitlab_url = match Url::parse(value) {
                 Ok(gitlab_url) => gitlab_url,
                 Err(parse_error) => {
-                    eprintln!("Failed to parse URL in environment variable {prefix}_GITLAB_URL: {parse_error}");
+                    warn!("Failed to parse URL in environment variable {prefix}_GITLAB_URL: {parse_error}");
                     continue;
                 }
             };
             let Some(gitlab_repo_format) = env_vars.get(&format!("{prefix}_GITLAB_REPO_FORMAT")).cloned() else {
-                eprintln!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_REPO_FORMAT is also required but it is missing");
+                warn!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_REPO_FORMAT is also required but it is missing");
                 continue;
             };
             let Some(gitlab_api_access_token) = env_vars.get(&format!("{prefix}_GITLAB_API_ACCESS_TOKEN")).cloned() else {
-                eprintln!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_API_ACCESS_TOKEN is also required but it is missing");
+                warn!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_API_ACCESS_TOKEN is also required but it is missing");
                 continue;
             };
             configs.insert(prefix.to_string(), GitLabServerConfig {

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -76,10 +76,10 @@ impl GitLabProjectAccessTokenProvider {
     pub async fn create_token(
         &self,
         requester: &AppId,
-        prefix: &str,
+        provider: &str,
     ) -> Result<SecretResult, String> {
-        let Some(config) = self.configs.get(prefix) else {
-            return Err(format!("A secret sync client requested a project access token for the GitLab ID {prefix} but it is not configured"));
+        let Some(config) = self.configs.get(provider) else {
+            return Err(format!("A secret sync client requested a project access token for the GitLab provider '{provider}' but it is not configured"));
         };
         let name = requester.as_ref().split('.').nth(1).unwrap();
         let gitlab_repo = config.gitlab_repo_format.replace('#', name);
@@ -145,11 +145,11 @@ impl GitLabProjectAccessTokenProvider {
     pub async fn validate_token(
         &self,
         requester: &AppId,
-        prefix: &str,
+        provider: &str,
         secret: &str,
     ) -> Result<bool, String> {
-        let Some(config) = self.configs.get(prefix) else {
-            return Err(format!("A secret sync client requested a project access token for the GitLab ID {prefix} but it is not configured"));
+        let Some(config) = self.configs.get(provider) else {
+            return Err(format!("A secret sync client requested a project access token for the GitLab provider '{provider}' but it is not configured"));
         };
         let name = requester.as_ref().split('.').nth(1).unwrap();
         let gitlab_repo = config.gitlab_repo_format.replace('#', name);

--- a/central/src/main.rs
+++ b/central/src/main.rs
@@ -113,14 +113,14 @@ pub async fn create_secret(
             let name = requester.as_ref().split('.').nth(1).unwrap();
             oidc_provider.create_client(name, oidc_client_config).await
         }
-        SecretRequest::GitLabProjectAccessToken => {
+        SecretRequest::GitLabProjectAccessToken(client_config) => {
             let Some(gitlab_project_access_token_provider) =
                 GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER.as_ref()
             else {
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .create_token(requester)
+                .create_token(requester, &client_config.prefix)
                 .await
         }
     }
@@ -141,14 +141,14 @@ pub async fn is_valid(
                 .validate_client(name, secret, oidc_client_config)
                 .await
         }
-        SecretRequest::GitLabProjectAccessToken => {
+        SecretRequest::GitLabProjectAccessToken(client_config) => {
             let Some(gitlab_project_access_token_provider) =
                 GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER.as_ref()
             else {
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .validate_token(requester, secret)
+                .validate_token(requester, &client_config.prefix, secret)
                 .await
         }
     }

--- a/central/src/main.rs
+++ b/central/src/main.rs
@@ -120,7 +120,7 @@ pub async fn create_secret(
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .create_token(requester, &client_config.prefix)
+                .create_token(requester, &client_config.provider)
                 .await
         }
     }
@@ -148,7 +148,7 @@ pub async fn is_valid(
                 return Err("No GitLab project access token provider configured!".into());
             };
             gitlab_project_access_token_provider
-                .validate_token(requester, &client_config.prefix, secret)
+                .validate_token(requester, &client_config.provider, secret)
                 .await
         }
     }

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -74,7 +74,7 @@ impl FromStr for SecretArg {
             }
             "GitLabProjectAccessToken" => Ok(SecretRequest::GitLabProjectAccessToken(
                 shared::GitLabClientConfig {
-                    prefix: args.to_string(),
+                    provider: args.to_string(),
                 },
             )),
             _ => Err(format!("Unknown secret type {secret_type}")),

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -72,9 +72,11 @@ impl FromStr for SecretArg {
                     is_public,
                 }))
             }
-            "GitLabProjectAccessToken" => {
-                Ok(SecretRequest::GitLabProjectAccessToken)
-            }
+            "GitLabProjectAccessToken" => Ok(SecretRequest::GitLabProjectAccessToken(
+                shared::GitLabClientConfig {
+                    prefix: args.to_string(),
+                },
+            )),
             _ => Err(format!("Unknown secret type {secret_type}")),
         }?;
 

--- a/local/src/main.rs
+++ b/local/src/main.rs
@@ -107,7 +107,7 @@ async fn send_secret_request(
     for secret_request in secret_requests {
         match secret_request.deref() {
             SecretRequest::OpenIdConnect(_) => oidc_requests.push(secret_request),
-            SecretRequest::GitLabProjectAccessToken => {
+            SecretRequest::GitLabProjectAccessToken(_) => {
                 gitlab_project_access_token_requests.push(secret_request)
             }
         }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,13 +5,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum SecretRequest {
     OpenIdConnect(OIDCConfig),
-    GitLabProjectAccessToken,
+    GitLabProjectAccessToken(GitLabClientConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OIDCConfig {
     pub is_public: bool,
     pub redirect_urls: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct GitLabClientConfig {
+    pub prefix: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -16,7 +16,7 @@ pub struct OIDCConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GitLabClientConfig {
-    pub prefix: String,
+    pub provider: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
The accompanying bridgehead PR is https://github.com/samply/bridgehead/pull/278 and it must be merged and deployed *before* this PR is merged.

Some projects like BBMRI have their configuration repositories split accross different GitLab servers, e.g. verbis GitLab and BBMRI GitLab. This commit supports configuring multiple GitLab servers.