### PR TITLE
Rotate gitlab tokens instead of creating new ones

### DIFF
--- a/central/Cargo.toml
+++ b/central/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "central"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/central/Cargo.toml
+++ b/central/Cargo.toml
@@ -19,6 +19,6 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 urlencoding = "2.1.3"
-chrono = "0.4"
 icinga-client = { git = "https://github.com/samply/icinga-client.git", tag = "v0.1.0", version = "0.1.0" }
 toml = "0.8.20"
+time = { version = "0.3.41", features = ["serde", "parsing", "macros", "formatting"] }

--- a/central/src/auth/authentik/mod.rs
+++ b/central/src/auth/authentik/mod.rs
@@ -109,11 +109,11 @@ pub async fn validate_application(
 
 pub async fn create_app_provider(
     name: &str,
-    oidc_client_config: OIDCConfig,
+    oidc_client_config: &OIDCConfig,
     conf: &AuthentikConfig,
 ) -> anyhow::Result<SecretResult> {
     let token = get_access_token(conf).await?;
-    combine_app_provider(&token, name, &oidc_client_config, conf).await
+    combine_app_provider(&token, name, oidc_client_config, conf).await
 }
 
 pub async fn combine_app_provider(

--- a/central/src/auth/keycloak/mod.rs
+++ b/central/src/auth/keycloak/mod.rs
@@ -33,7 +33,7 @@ pub struct KeyCloakConfig {
 
 pub async fn create_client(
     name: &str,
-    oidc_client_config: OIDCConfig,
+    oidc_client_config: &OIDCConfig,
     conf: &KeyCloakConfig,
 ) -> anyhow::Result<SecretResult> {
     let token = get_access_token(conf).await?;

--- a/central/src/gitlab.rs
+++ b/central/src/gitlab.rs
@@ -1,16 +1,18 @@
 use std::collections::HashMap;
 
-use beam_lib::{reqwest::Url, AppId};
-use clap::Parser;
+use beam_lib::{reqwest::Url, AppId, ProxyId};
 use icinga_client::{IcingaProcessResult, IcingaServiceState, IcingaState};
 use serde::Deserialize;
 use serde_json::json;
-use shared::SecretResult;
+use shared::{GitlabClientConfig, RequestType, SecretResult};
 use tracing::warn;
+
+const TOKEN_LIFETIME: chrono::Duration = chrono::Duration::days(30);
+const MIN_REMAINING_TIME: chrono::Duration = chrono::Duration::days(15);
 
 use crate::{CONFIG, ICINGA_CLIENT};
 
-struct GitLabServerConfig {
+struct GitlabConfig {
     /// The base URL for API calls, e.g. "https://gitlab.com/"
     pub gitlab_url: Url,
     /// Format of the repository name on GitLab. Must contain a "#" which is replaced with the site name. Example: "bridgehead-configurations/bridgehead-config-#"
@@ -20,16 +22,21 @@ struct GitLabServerConfig {
 }
 
 #[derive(Deserialize)]
-struct GitLabApiReponseBody {
+struct CreateTokenResponse {
     token: String,
 }
 
-pub struct GitLabProjectAccessTokenProvider {
-    configs: HashMap<String, GitLabServerConfig>,
+#[derive(Deserialize, Debug)]
+struct TokenDetailsResponse {
+    expires_at: String,
+}
+
+pub struct GitlabTokenProvider {
+    gitlab_configs: HashMap<String, GitlabConfig>,
     client: reqwest::Client,
 }
 
-fn parse_env_vars() -> HashMap<String, GitLabServerConfig> {
+fn parse_env_vars() -> HashMap<String, GitlabConfig> {
     let mut configs = HashMap::new();
     let env_vars: HashMap<String, String> = std::env::vars().collect();
     for (name, value) in &env_vars {
@@ -41,123 +48,85 @@ fn parse_env_vars() -> HashMap<String, GitLabServerConfig> {
                     continue;
                 }
             };
-            let Some(gitlab_repo_format) = env_vars.get(&format!("{prefix}_GITLAB_REPO_FORMAT")).cloned() else {
+            let Some(gitlab_repo_format) = env_vars
+                .get(&format!("{prefix}_GITLAB_REPO_FORMAT"))
+                .cloned()
+            else {
                 warn!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_REPO_FORMAT is also required but it is missing");
                 continue;
             };
-            let Some(gitlab_api_access_token) = env_vars.get(&format!("{prefix}_GITLAB_API_ACCESS_TOKEN")).cloned() else {
+            let Some(gitlab_api_access_token) = env_vars
+                .get(&format!("{prefix}_GITLAB_API_ACCESS_TOKEN"))
+                .cloned()
+            else {
                 warn!("Because the environment variable {prefix}_GITLAB_URL is present {prefix}_GITLAB_API_ACCESS_TOKEN is also required but it is missing");
                 continue;
             };
-            configs.insert(prefix.to_string(), GitLabServerConfig {
-                gitlab_url,
-                gitlab_repo_format,
-                gitlab_api_access_token,
-            });
+            configs.insert(
+                prefix.to_string(),
+                GitlabConfig {
+                    gitlab_url,
+                    gitlab_repo_format,
+                    gitlab_api_access_token,
+                },
+            );
         }
     }
     return configs;
 }
 
-impl GitLabProjectAccessTokenProvider {
+impl GitlabTokenProvider {
     pub fn try_init() -> Option<Self> {
         let configs = parse_env_vars();
         if configs.is_empty() {
             None
         } else {
             Some(Self {
-                configs: configs,
+                gitlab_configs: configs,
                 client: reqwest::Client::new(),
             })
         }
     }
 
-    /// Create a project access token using the GitLab API
-    pub async fn create_token(
+    pub async fn handle_secret_request(
         &self,
-        requester: &AppId,
-        provider: &str,
+        request_type: RequestType,
+        client_config: &GitlabClientConfig,
+        from: &AppId,
     ) -> Result<SecretResult, String> {
-        let Some(config) = self.configs.get(provider) else {
-            return Err(format!("A secret sync client requested a project access token for the GitLab provider '{provider}' but it is not configured"));
+        let Some(gitlab_config) = self.gitlab_configs.get(&client_config.gitlab_instance) else {
+            return Err(format!(
+                "GitLab server '{}' is not configured",
+                client_config.gitlab_instance
+            ));
         };
-        let name = requester.as_ref().split('.').nth(1).unwrap();
-        let gitlab_repo = config.gitlab_repo_format.replace('#', name);
 
-        // Expire in 1 week
-        let expires_at = (chrono::Local::now() + chrono::TimeDelta::weeks(1))
-            .format("%Y-%m-%d")
-            .to_string();
-
-        let response = self
-            .client
-            .post(
-                config
-                    .gitlab_url
-                    .join(&format!(
-                        "api/v4/projects/{}/access_tokens",
-                        urlencoding::encode(&gitlab_repo)
-                    ))
-                    .map_err(|e| e.to_string())?,
-            )
-            .header("PRIVATE-TOKEN", &config.gitlab_api_access_token)
-            .json(&json!({
-                "name": requester,
-                // The "read_repository" scope is required for git clone/pull permissions
-                "scopes": ["read_repository"],
-                // Access level 20 (Reporter) is the lowest level that allows git clone/pull
-                "access_level": 20,
-                "expires_at": expires_at,
-            }))
-            .send()
-            .await
-            .map_err(|e| e.to_string())?;
-
-        if response.status().is_success() {
-            let body: GitLabApiReponseBody = response.json().await.map_err(|e| e.to_string())?;
-            report_to_icinga(
-                requester,
-                IcingaServiceState::Ok,
-                format!("Site {name} has successfully retrieved a new GitLab token for {}{}", config.gitlab_url, gitlab_repo),
-                "rotate",
-            )
-            .await;
-            Ok(SecretResult::Created(body.token))
-        } else {
-            let err_msg = format!(
-                "HTTP status error {} for url {} with body {}",
-                response.status(),
-                response.url().clone(),
-                response.text().await.map_err(|e| e.to_string())?
-            );
-            report_to_icinga(
-                requester,
-                IcingaServiceState::Warning,
-                format!("Site {name} requested a GitLab token but it could not be created: {err_msg}"),
-                "rotate",
-            )
-            .await;
-            Err(err_msg)
+        match request_type {
+            RequestType::ValidateOrCreate(current_token) => {
+                self.validate_or_create_workaround(&from.proxy_id(), gitlab_config, &current_token)
+                    .await
+            }
+            RequestType::Create => self.create(&from.proxy_id(), gitlab_config).await,
         }
     }
 
-    /// Simulate a git fetch to check the validity of the token
-    pub async fn validate_token(
+    // Workaround for https://gitlab.com/gitlab-org/gitlab/-/issues/523871
+    // If they ever fix this, we can remove this function and use the validate_or_create function
+    async fn validate_or_create_workaround(
         &self,
-        requester: &AppId,
-        provider: &str,
-        secret: &str,
-    ) -> Result<bool, String> {
-        let Some(config) = self.configs.get(provider) else {
-            return Err(format!("A secret sync client requested a project access token for the GitLab provider '{provider}' but it is not configured"));
-        };
-        let name = requester.as_ref().split('.').nth(1).unwrap();
-        let gitlab_repo = config.gitlab_repo_format.replace('#', name);
+        site: &ProxyId,
+        gitlab_config: &GitlabConfig,
+        current_token: &str,
+    ) -> Result<SecretResult, String> {
+        let gitlab_repo = gitlab_config
+            .gitlab_repo_format
+            .replace('#', site.as_ref().split('.').nth(0).unwrap());
 
+        // Simulate a git fetch to check if the token is valid
         let response = self
             .client
             .get(
-                config
+                gitlab_config
                     .gitlab_url
                     .join(&format!(
                         "{}.git/info/refs?service=git-upload-pack",
@@ -165,24 +134,286 @@ impl GitLabProjectAccessTokenProvider {
                     ))
                     .map_err(|e| e.to_string())?,
             )
-            .basic_auth("secret-sync", Some(secret)) // Any non-empty username works, only the secret matters
+            .basic_auth("Secret Sync", Some(current_token))
             .send()
             .await
             .map_err(|e| e.to_string())?;
 
+        if !response.status().is_success() {
+            // If the token does not work, create a new one
+            return self.create(site, gitlab_config).await;
+        }
+
+        // List all active tokens with the name "Secret Sync Token for {site}"
+        let response = self
+            .client
+            .get(
+                gitlab_config
+                    .gitlab_url
+                    .join(&format!(
+                        "api/v4/projects/{}/access_tokens?state=active&search={}",
+                        urlencoding::encode(&gitlab_repo),
+                        urlencoding::encode(&format!("Secret Sync Token for {site}"))
+                    ))
+                    .map_err(|e| e.to_string())?,
+            )
+            .header("PRIVATE-TOKEN", &gitlab_config.gitlab_api_access_token)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !response.status().is_success() {
+            let err_msg = format!(
+                "HTTP status error {} for url {} with body {}",
+                response.status(),
+                response.url().clone(),
+                response.text().await.map_err(|e| e.to_string())?
+            );
+            report_to_icinga(
+                site,
+                IcingaServiceState::Warning,
+                format!("Failed to list tokens: {err_msg}"),
+                "validate",
+            )
+            .await;
+            return Err(format!("Failed to list tokens: {err_msg}"));
+        }
+
+        let response: Vec<TokenDetailsResponse> =
+            response.json().await.map_err(|e| e.to_string())?;
+
+        // Check if all active tokens are still valid for at least MIN_REMAINING_TIME
+        if response.iter().all(|token| {
+            let expires_at = chrono::NaiveDate::parse_from_str(&token.expires_at, "%Y-%m-%d")
+                .map_err(|e| e.to_string())
+                .unwrap();
+            expires_at - chrono::Local::now().date_naive() >= MIN_REMAINING_TIME
+        }) {
+            report_to_icinga(
+                site,
+                IcingaServiceState::Ok,
+                format!(
+                    "Site {site} validated their GitLab token for {}{}. The token is valid for at least {} more days.",
+                    gitlab_config.gitlab_url,
+                    gitlab_repo,
+                    MIN_REMAINING_TIME.num_days()
+                ),
+                "validate",
+            )
+            .await;
+            return Ok(SecretResult::AlreadyValid);
+        }
+
+        // Rotate the token
+        let response = self
+            .client
+            .post(
+                gitlab_config
+                    .gitlab_url
+                    .join(&format!(
+                        "api/v4/projects/{}/access_tokens/self/rotate",
+                        urlencoding::encode(&gitlab_repo)
+                    ))
+                    .map_err(|e| e.to_string())?,
+            )
+            .header("PRIVATE-TOKEN", current_token)
+            .json(&json!({
+                "expires_at": (chrono::Local::now() + TOKEN_LIFETIME).format("%Y-%m-%d").to_string(),
+            }))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !response.status().is_success() {
+            let err_msg = format!(
+                "HTTP status error {} for url {} with body {}",
+                response.status(),
+                response.url().clone(),
+                response.text().await.map_err(|e| e.to_string())?
+            );
+            report_to_icinga(
+                site,
+                IcingaServiceState::Warning,
+                format!("Failed to rotate the token: {err_msg}"),
+                "rotate",
+            )
+            .await;
+            return Err(format!("Failed to rotate the token: {err_msg}"));
+        }
+
+        let response: CreateTokenResponse = response.json().await.map_err(|e| e.to_string())?;
+        Ok(SecretResult::AlreadyExisted(response.token))
+    }
+
+    // When GitLab fixes https://gitlab.com/gitlab-org/gitlab/-/issues/523871, we can use this function instead of the workaround
+    #[allow(dead_code)]
+    async fn validate_or_create(
+        &self,
+        site: &ProxyId,
+        gitlab_config: &GitlabConfig,
+        current_token: &str,
+    ) -> Result<SecretResult, String> {
+        let gitlab_repo = gitlab_config
+            .gitlab_repo_format
+            .replace('#', site.as_ref().split('.').nth(0).unwrap());
+
+        // Check when the token will expire
+        let response = self
+            .client
+            .get(
+                gitlab_config
+                    .gitlab_url
+                    .join(&format!(
+                        "api/v4/projects/{}/access_tokens/self",
+                        urlencoding::encode(&gitlab_repo)
+                    ))
+                    .map_err(|e| e.to_string())?,
+            )
+            .header("PRIVATE-TOKEN", current_token)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !response.status().is_success() {
+            // This means the token is invalid or expired, so we need to create a new one
+            return self.create(site, gitlab_config).await;
+        }
+
+        // Check if the token is still valid for at least MIN_REMAINING_TIME
+        let response: TokenDetailsResponse = response.json().await.map_err(|e| e.to_string())?;
+        let expires_at = chrono::NaiveDate::parse_from_str(&response.expires_at, "%Y-%m-%d")
+            .map_err(|e| e.to_string())?;
+        if expires_at - chrono::Local::now().date_naive() >= MIN_REMAINING_TIME {
+            report_to_icinga(
+                site,
+                IcingaServiceState::Ok,
+                format!(
+                    "Site {site} validated their GitLab token for {}{}. The token is valid for {} more days.",
+                    gitlab_config.gitlab_url,
+                    gitlab_repo,
+                    (expires_at - chrono::Local::now().date_naive()).num_days()
+                ),
+                "validate",
+            )
+            .await;
+            return Ok(SecretResult::AlreadyValid);
+        }
+
+        // Rotate the token
+        let response = self
+            .client
+            .post(
+                gitlab_config
+                    .gitlab_url
+                    .join(&format!(
+                        "api/v4/projects/{}/access_tokens/self/rotate",
+                        urlencoding::encode(&gitlab_repo)
+                    ))
+                    .map_err(|e| e.to_string())?,
+            )
+            .header("PRIVATE-TOKEN", current_token)
+            .json(&json!({
+                "expires_at": (chrono::Local::now() + TOKEN_LIFETIME).format("%Y-%m-%d").to_string(),
+            }))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !response.status().is_success() {
+            let err_msg = format!(
+                "HTTP status error {} for url {} with body {}",
+                response.status(),
+                response.url().clone(),
+                response.text().await.map_err(|e| e.to_string())?
+            );
+            report_to_icinga(
+                site,
+                IcingaServiceState::Warning,
+                format!("Failed to rotate the token: {err_msg}"),
+                "rotate",
+            )
+            .await;
+            return Err(format!("Failed to rotate the token: {err_msg}"));
+        }
+
+        let response: CreateTokenResponse = response.json().await.map_err(|e| e.to_string())?;
+        Ok(SecretResult::AlreadyExisted(response.token))
+    }
+
+    async fn create(
+        &self,
+        site: &ProxyId,
+        gitlab_config: &GitlabConfig,
+    ) -> Result<SecretResult, String> {
+        let gitlab_repo = gitlab_config
+            .gitlab_repo_format
+            .replace('#', site.as_ref().split('.').nth(0).unwrap());
+
+        // Create a new token
+        let response = self
+            .client
+            .post(
+                gitlab_config
+                    .gitlab_url
+                    .join(&format!(
+                        "api/v4/projects/{}/access_tokens",
+                        urlencoding::encode(&gitlab_repo)
+                    ))
+                    .map_err(|e| e.to_string())?,
+            )
+            .header("PRIVATE-TOKEN", &gitlab_config.gitlab_api_access_token)
+            .json(&json!({
+                "name": format!("Secret Sync Token for {site}"),
+                // The "read_repository" scope is required for git clone/pull permissions
+                "scopes": ["read_repository", "self_rotate"],
+                // Access level 20 (Reporter) is the lowest level that allows git clone/pull
+                "access_level": 20,
+                "expires_at": (chrono::Local::now() + TOKEN_LIFETIME).format("%Y-%m-%d").to_string(),
+            }))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if !response.status().is_success() {
+            let err_msg = format!(
+                "HTTP status error {} for url {} with body {}",
+                response.status(),
+                response.url().clone(),
+                response.text().await.map_err(|e| e.to_string())?
+            );
+            report_to_icinga(
+                site,
+                IcingaServiceState::Warning,
+                format!("Failed to create the token: {err_msg}"),
+                "rotate",
+            )
+            .await;
+            return Err(format!("Failed to create the token: {err_msg}"));
+        }
+
+        let response: CreateTokenResponse = response.json().await.map_err(|e| e.to_string())?;
         report_to_icinga(
-            requester,
+            site,
             IcingaServiceState::Ok,
-            format!("Site {name} has successfully validated an existing GitLab token for {}{}", config.gitlab_url, gitlab_repo),
-            "validate",
+            format!(
+                "Site {site} created a GitLab token for {}{}. The token is valid for {} more days.",
+                gitlab_config.gitlab_url,
+                gitlab_repo,
+                TOKEN_LIFETIME.num_days()
+            ),
+            "rotate",
         )
         .await;
-
-        Ok(response.status().is_success())
+        Ok(SecretResult::Created(response.token))
     }
 }
 
-pub async fn report_to_icinga(requester: &AppId, state: IcingaServiceState, message: String, action: &str) {
+pub async fn report_to_icinga(
+    site: &ProxyId,
+    state: IcingaServiceState,
+    message: String,
+    action: &str,
+) {
     let Some(icinga_client) = ICINGA_CLIENT.as_ref() else {
         return;
     };
@@ -194,8 +425,7 @@ pub async fn report_to_icinga(requester: &AppId, state: IcingaServiceState, mess
             plugin_output: message.clone(),
             filter: format!(
                 "host.address==\"{}\" && service.name==\"bridgehead-git-access-token-rotation-{}\"",
-                requester.proxy_id(),
-                action,
+                site, action,
             ),
             ..Default::default()
         })

--- a/dev-gitlab/container-setup-scripts/pki-setup.sh
+++ b/dev-gitlab/container-setup-scripts/pki-setup.sh
@@ -1,0 +1,12 @@
+set -e
+
+echo "$VAULT_TOKEN" > /pki/pki.secret
+
+vault secrets enable -path=samply_pki pki
+
+vault write -field=certificate samply_pki/root/generate/internal common_name=broker > /pki/root.crt.pem
+
+vault write samply_pki/roles/myrole allowed_domains=broker allow_subdomains=true
+
+vault write -field=private_key samply_pki/issue/myrole common_name=central-proxy.broker ttl=30d > /pki/central-proxy.priv.pem
+vault write -field=private_key samply_pki/issue/myrole common_name=dev-tim.broker ttl=30d > /pki/dev-tim.priv.pem

--- a/dev-gitlab/docker-compose.yaml
+++ b/dev-gitlab/docker-compose.yaml
@@ -1,52 +1,77 @@
-version: "3"
-
-# This docker-compose.yaml requires that the beam demo network is running on the same computer. To run the beam demo
-# network run`./dev/beamdev demo` in the beam repository. It also assumes that the beam repository is located at
-# `../../beam` relative to this directory. If your beam directory is located somewhere else, you can overwrite this
-# default with the `BEAM_DIR` environment variable. It is recommended to set the GITLAB_API_ACCESS_TOKEN environment
-# variable in the `.env` file which is part of .gitignore and automatically loaded by docker compose.
-
 services:
-  # This container contains both a beam proxy (proxy1.broker) and the secret sync local component (secret-sync.proxy1.broker)
-  local:
-    build:
-      context: ../
-      dockerfile: Dockerfile.local
+  vault:
+    image: hashicorp/vault:latest
     environment:
-      - PROXY_ID=proxy1.broker
-      - GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER=app2.proxy2.broker
-      - BROKER_URL=http://broker:8080
-      - SECRET_DEFINITIONS=GitLabProjectAccessToken:GIT_CONFIG_REPO_TOKEN:bridgehead-configuration
-      - CACHE_PATH=/usr/local/cache/cache.txt
-    volumes:
-      - ./cache:/usr/local/cache
-    secrets:
-      - privkey.pem
-      - root.crt.pem
-    networks:
-      - dev_default
+      VAULT_DEV_ROOT_TOKEN_ID: vaulttoken123
 
-  # This container contains the secret sync central component (app2.proxy2.broker)
+  pki-setup:
+    image: hashicorp/vault:latest
+    environment:
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: vaulttoken123
+    volumes:
+      - ./container-setup-scripts/pki-setup.sh:/pki-setup.sh:ro
+      - pki:/pki
+    command: sh /pki-setup.sh
+
+  broker:
+    image: samply/beam-broker:main
+    depends_on:
+      pki-setup:
+        condition: service_completed_successfully
+    environment:
+      BROKER_URL: http://broker:8080
+      PKI_ADDRESS: http://vault:8200
+      PKI_APIKEY_FILE: /pki/pki.secret
+      ROOTCERT_FILE: /pki/root.crt.pem
+    volumes:
+      - pki:/pki:ro
+
+  central-proxy:
+    image: samply/beam-proxy:main
+    depends_on:
+      - broker
+    environment:
+      BROKER_URL: http://broker:8080
+      PROXY_ID: central-proxy.broker
+      APP_central_KEY: centralkey123
+      PRIVKEY_FILE: /pki/central-proxy.priv.pem
+      ROOTCERT_FILE: /pki/root.crt.pem
+    volumes:
+      - pki:/pki:ro
+
   central:
     build:
       context: ../
       dockerfile: Dockerfile.central
+    depends_on:
+      - central-proxy
     environment:
-      - BEAM_URL=http://proxy2:8082
-      - BEAM_ID=app2.proxy2.broker
-      - BEAM_SECRET=App1Secret
-      - GITLAB_URL=https://git.verbis.dkfz.de/
-      - GITLAB_API_ACCESS_TOKEN=${GITLAB_API_ACCESS_TOKEN}
-    networks:
-      - dev_default
+      - BEAM_URL=http://central-proxy:8081
+      - BEAM_ID=central.central-proxy.broker
+      - BEAM_SECRET=centralkey123
+      - verbis_GITLAB_URL=https://git.verbis.dkfz.de
+      - verbis_GITLAB_REPO_FORMAT=bridgehead-configurations/bridgehead-config-#
+      - verbis_GITLAB_API_ACCESS_TOKEN=${GITLAB_API_ACCESS_TOKEN}
 
-secrets:
-  privkey.pem:
-    file: ${BEAM_DIR:-../../beam}/dev/pki/proxy1.priv.pem
-  root.crt.pem:
-    file: ${BEAM_DIR:-../../beam}/dev/pki/root.crt.pem
+  # This container contains both a beam proxy and the secret sync local component
+  local:
+    build:
+      context: ../
+      dockerfile: Dockerfile.local
+    depends_on:
+      - central
+    environment:
+      - PROXY_ID=dev-tim.broker
+      - GITLAB_PROJECT_ACCESS_TOKEN_PROVIDER=central.central-proxy.broker
+      - PRIVKEY_FILE=/pki/dev-tim.priv.pem
+      - ROOTCERT_FILE=/pki/root.crt.pem
+      - BROKER_URL=http://broker:8080
+      - SECRET_DEFINITIONS=GitLabProjectAccessToken:GIT_CONFIG_REPO_TOKEN:verbis
+      - CACHE_PATH=/usr/local/cache/cache.txt
+    volumes:
+      - ./cache:/usr/local/cache
+      - pki:/pki:ro
 
-networks:
-  # Add our containers to the beam demo Docker network
-  dev_default:
-    external: true
+volumes:
+  pki:

--- a/dev-gitlab/run.sh
+++ b/dev-gitlab/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(dirname "$0")
+
+docker compose down --volumes
+docker compose up "$@"
+docker compose down --volumes

--- a/local/Cargo.toml
+++ b/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -2,7 +2,7 @@ use std::{convert::Infallible, path::PathBuf, str::FromStr};
 
 use beam_lib::AppId;
 use clap::Parser;
-use shared::{OIDCConfig, SecretRequest};
+use shared::{OIDCConfig, SecretType};
 
 /// Local secret sync
 #[derive(Debug, Parser)]
@@ -46,7 +46,7 @@ impl FromStr for SecretDefinitions {
 #[derive(Debug, Clone)]
 pub struct SecretArg {
     pub name: String,
-    pub request: SecretRequest,
+    pub request: SecretType,
 }
 
 impl FromStr for SecretArg {
@@ -67,14 +67,14 @@ impl FromStr for SecretArg {
                     _ => return Err(format!("Invalid OIDC parameters '{args}'. Syntax is <public|private>;<redirect_url1,redirect_url2,...>")),
                 };
                 let redirect_urls = args.split(',').map(ToString::to_string).collect();
-                Ok(SecretRequest::OpenIdConnect(OIDCConfig {
+                Ok(SecretType::OpenIdConnect(OIDCConfig {
                     redirect_urls,
                     is_public,
                 }))
             }
-            "GitLabProjectAccessToken" => Ok(SecretRequest::GitLabProjectAccessToken(
-                shared::GitLabClientConfig {
-                    provider: args.to_string(),
+            "GitLabProjectAccessToken" => Ok(SecretType::GitLabProjectAccessToken(
+                shared::GitlabClientConfig {
+                    gitlab_instance: args.to_string(),
                 },
             )),
             _ => Err(format!("Unknown secret type {secret_type}")),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,11 +1,9 @@
-use std::ops::Deref;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum SecretRequest {
+pub enum SecretType {
     OpenIdConnect(OIDCConfig),
-    GitLabProjectAccessToken(GitLabClientConfig),
+    GitLabProjectAccessToken(GitlabClientConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -15,8 +13,9 @@ pub struct OIDCConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GitLabClientConfig {
-    pub provider: String,
+pub struct GitlabClientConfig {
+    /// Which GitLab server to use, e.g. 'verbis' or 'bbmri'
+    pub gitlab_instance: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -27,21 +26,13 @@ pub enum SecretResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum SecretRequestType {
-    ValidateOrCreate {
-        current: String,
-        request: SecretRequest,
-    },
-    Create(SecretRequest),
+pub enum RequestType {
+    ValidateOrCreate(String),
+    Create,
 }
 
-impl Deref for SecretRequestType {
-    type Target = SecretRequest;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            SecretRequestType::ValidateOrCreate { request, .. }
-            | SecretRequestType::Create(request) => request,
-        }
-    }
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SecretRequest {
+    pub request_type: RequestType,
+    pub secret_type: SecretType,
 }


### PR DESCRIPTION
First I wrote `validate_or_create`, then I noticed the GitLab API does not work as advertised and then wrote `validate_or_create_workaround` with the following strategy:
1. Test the current token by simulating a git fetch if it does not work create new token and return it
2. Check if all active tokens still have enough time remaining. Since our token is an active token (confirmed in step 1) we know that our token also has enough time remaining and we can return `AlreadyValid`.
3. Rotate the current token and return the new one

If they ever fix https://gitlab.com/gitlab-org/gitlab/-/issues/523871 we can remove the workaround. The non-workaround function `validate_or_create` simply calls an endpoint that checks if the current token is still valid and returns the expiry date, but that endpoint is currently broken.

This PR also refactors the secret request type. Previously:

```rust
pub enum SecretRequestType {
    ValidateOrCreate {
        current: String,
        request: SecretRequest,
    },
    Create(SecretRequest),
}
pub enum SecretRequest {
    OpenIdConnect(OIDCConfig),
    GitLabProjectAccessToken(GitLabClientConfig),
}
```

Now:

```rust
pub enum SecretType {
    OpenIdConnect(OIDCConfig),
    GitLabProjectAccessToken(GitlabClientConfig),
}
pub enum RequestType {
    ValidateOrCreate(String),
    Create,
}
pub struct SecretRequest {
    pub request_type: RequestType,
    pub secret_type: SecretType,
}
```

This "decouples" the secret type (GitLab, OIDC) from the request type (ValidOrCreate, Create). This allows us to first match on the secret type and call the dedicated handler, which can than handle the request types in their own fashion. Specifically the old request type handling assumed that we would first validate the token and if that fails create a new one, without any considering of creating a new token *with* the old token, i.e. token rotation.