### PR TITLE
Changed: Minimal password length 32

### DIFF
--- a/central/src/auth/mod.rs
+++ b/central/src/auth/mod.rs
@@ -6,7 +6,7 @@ pub fn generate_secret() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                             abcdefghijklmnopqrstuvwxyz\
                             0123456789";
-    const PASSWORD_LEN: usize = 30;
+    const PASSWORD_LEN: usize = 32;
     let mut rng = rand::thread_rng();
 
     (0..PASSWORD_LEN)


### PR DESCRIPTION
**Summary**

After logging into Opal using Authentik as the OIDC provider, we encountered the following error:

```yaml
2025-07-07 12:35:25.715 | Caused by: com.nimbusds.jose.KeyLengthException: The secret length must be at least 256 bits
2025-07-07 12:35:25.715 | 	at com.nimbusds.jose.crypto.impl.MACProvider.<init>(MACProvider.java:118)
2025-07-07 12:35:25.715 | 	at com.nimbusds.jose.crypto.MACVerifier.<init>(MACVerifier.java:168)
```

**Cause**

The error was caused by the OIDC client secret (password) being too short. The current password was 30 characters long, but the MACVerifier requires a minimum of 256 bits (32 characters) for HMAC algorithms.

**Fix**

We increased the default password length by updating the value of **PASSWORD_LEN** from 30 to 32 characters to satisfy the required key length for OIDC authentication.