### PR TITLE
redirect url expand

### DIFF
--- a/central/src/auth/authentik/provider.rs
+++ b/central/src/auth/authentik/provider.rs
@@ -46,7 +46,7 @@ pub async fn generate_provider_values(
                     url: convert_to_regex_url(url),
                 });
             } else {
-                if url.ends_with("callback") && !oidc_client_config.is_public {
+                if url.ends_with("/oauth2-idm/callback") && !oidc_client_config.is_public {
                     res_urls.push(RedirectURIS {
                         matching_mode: "strict".to_owned(),
                         url: expand_redirect_url(url),

--- a/central/src/auth/authentik/test.rs
+++ b/central/src/auth/authentik/test.rs
@@ -55,7 +55,7 @@ async fn test_create_client() -> anyhow::Result<()> {
             "http://dkfz/verbis/test".into(),
             "http://dkfz.verbis/*".into(),
             "https://e000-nb000.inet.dkfz-heidelberg.de/opal/*".into(),
-            "https://e000-nb000/callback".into(),
+            "https://e000-nb000/oauth2-idm/callback".into(),
         ],
     };
     let (SecretResult::Created(pw) | SecretResult::AlreadyExisted(pw)) =
@@ -81,7 +81,7 @@ async fn test_create_client() -> anyhow::Result<()> {
             "http://dkfz/verbis/test".into(),
             "http://dkfz.verbis/*".into(),
             "https://e000-nb000.inet.dkfz-heidelberg.de/opal/*".into(),
-            "https://e000-nb000/callback".into(),
+            "https://e000-nb000/oauth2-idm/callback".into(),
         ],
     };
     let (SecretResult::Created(pw) | SecretResult::AlreadyExisted(pw)) =


### PR DESCRIPTION
Redirect URLs needs to be expanded if it is a callback url
```
strict https://e000-nb000.inet.dkfz-heidelberg.de/callback
strict https://e000-nb000/callback
```
Checks if URL ends with „callback“
